### PR TITLE
Differentiate between hash and identifier

### DIFF
--- a/blips/blip-2-researchcertificate.md
+++ b/blips/blip-2-researchcertificate.md
@@ -4,7 +4,7 @@
 | -------- | ------------------------------------------------------------ |
 | Title:   | Research Object Certification                                      |
 | Owner(s):  | James Lawton                                                           |
-| Author(s):  | James Lawton                                                           |
+| Author(s):  | James Lawton, Kevin Wittek                                                           |
 | Status:  | ![Draft] |
 | Created: | 2020-02-18                                                   |
 | License: | BSD-2-Clause                                                 |
@@ -47,7 +47,7 @@ For each transaction that certifies a single or batch of research objects, a cor
 The Research Object Certificate MUST conform to the [Verifiable Credentials](https://www.w3.org/TR/vc-data-model/) standard.
 Each owner of the token is able to augment the tokenURI field to a hosting location of their choosing that can resolve to a single or batch of certificates. Similar to DOI, it is the responsibility of each token owner to update the token URI.
 
-```json
+```json5
 {
     // Relevant JSON-LD context links in order to validate Verifiable Credentials according to their spec.
     "@context": ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/blockcerts/schema/3.0-alpha/context.json"], 
@@ -70,9 +70,9 @@ Each owner of the token is able to augment the tokenURI field to a hosting locat
     }, 
     // Html to render when certificate is verified - OPTIONAL.
     "displayHtml": "<h1>bloxberg Certificate</h1><h2>This bloxberg certificate serves as a proof of existence that the data corresponding to the SHA256 Hash were transacted on the bloxberg blockchain at the issued time.</h2>", 
-    // Cryptographic hash that is derived from the research object to certify. The exact hashing algorithm can be generalized, but must uniquely identify a file such as SHA256, SHA-3, or ISCC.
+    // Cryptographic identifier that is derived from the research object to certify. The exact hashing algorithm can be generalized, but must uniquely identify a file such as SHA256, SHA-3, or ISCC.
     "hash": "0x0e4ded5319861c8daac00d425c53a16bd180a7d01a340a0e00f7dede40d2c9f6", 
-    // Crytographic hashing mechanism used to derive value in *hash*.
+    // Crytographic identifier generation mechanism used to derive value in *hash*.
     "hashType": "SHA256",
     // Digital proof that ensures tamper-resistance.
     "proof": {
@@ -111,14 +111,14 @@ Steps to Verify Certificate:
 
 These steps ensure that the certificate is valid and secured on the bloxberg blockchain on the issuanceDate. Additional verification steps can be taken to ensure data integrity of any individual research object secured in a batch or individually:
 <ol>
-<li>Compute cryptographic hash of certified research object according to function listed in variable *hashType*.</li>
+<li>Compute cryptographic identifier of certified research object according to function listed in variable *hashType*.</li>
 <li>Compare computed value with value secured in research object certificate and ensure that they are identical.</li>
 </ol>
 
 ## References
 <ol>
 <li>Verifiable Credentials Data Model 1.0. https://www.w3.org/TR/vc-data-model/.</li>
-<li> Merkle Proof Signature Suite 2019. https://w3c-ccg.github.io/lds-merkle-proof-2019/.</li>
+<li>Merkle Proof Signature Suite 2019. https://w3c-ccg.github.io/lds-merkle-proof-2019/.</li>
 <li>International Standard Content Code. https://iscc.codes.</li>
 <li>ERC-721 Non-Fungible Token Standardhttps://eips.ethereum.org/EIPS/eip-721</li>
 </ol>


### PR DESCRIPTION
This comes mostly from the fact, the ISCC is not a hash by the strict definition, but an identifier, that is a composite of multiple different hashes. 

Also adds Kevin Wittek as author.